### PR TITLE
On Linux systems, resolve binary to full path

### DIFF
--- a/process_test.go
+++ b/process_test.go
@@ -2,6 +2,7 @@ package ps
 
 import (
 	"os"
+	"path"
 	"testing"
 )
 
@@ -33,7 +34,7 @@ func TestProcesses(t *testing.T) {
 
 	found := false
 	for _, p1 := range p {
-		if p1.Executable() == "go" || p1.Executable() == "go.exe" {
+		if path.Base(p1.Executable()) == "go" || path.Base(p1.Executable()) == "go.exe" {
 			found = true
 			break
 		}

--- a/process_unix.go
+++ b/process_unix.go
@@ -58,6 +58,12 @@ func (p *UnixProcess) Refresh() error {
 		&p.pgrp,
 		&p.sid)
 
+	// Optionally try to resolve the binary to a full path (Linux 2.2+)
+	exePath := fmt.Sprintf("/proc/%d/exe", p.pid)
+	if fullPath, err := os.Readlink(exePath); err == nil {
+		p.binary = fullPath
+	}
+
 	return err
 }
 


### PR DESCRIPTION
Processes with longer binary names are hard to find by
name with only the name found in /proc/<pid>/stat.